### PR TITLE
Use lowercase filenames for webpack

### DIFF
--- a/src/main/g8/webpack/scalajs-entry.js
+++ b/src/main/g8/webpack/scalajs-entry.js
@@ -1,13 +1,13 @@
 if (process.env.NODE_ENV === "production") {
-    const opt = require("./$name$-opt.js");
+    const opt = require("./$name;format="lower"$-opt.js");
     opt.main();
     module.exports = opt;
 } else {
     var exports = window;
-    exports.require = require("./$name$-fastopt-entrypoint.js").require;
+    exports.require = require("./$name;format="lower"$-fastopt-entrypoint.js").require;
     window.global = window;
 
-    const fastOpt = require("./$name$-fastopt.js");
+    const fastOpt = require("./$name;format="lower"$-fastopt.js");
     fastOpt.main()
     module.exports = fastOpt;
 


### PR DESCRIPTION
Scala.js bundler seems to output all the files with lowercase file names. Webpack is configured to use the giter8 `$name$` which may not be lowercase. On a case sensitive file system this causes webpack to fail. This ensures that webpack also looks for the lowercase file name.