### PR TITLE
ignore index.html in CopyWebpackPlugin

### DIFF
--- a/src/main/g8/webpack/webpack-core.config.js
+++ b/src/main/g8/webpack/webpack-core.config.js
@@ -35,7 +35,14 @@ module.exports = {
   plugins: [
     new CopyWebpackPlugin({
       patterns: [
-        { from: path.resolve(__dirname, "../../../../public") }
+        {
+          from: path.resolve(__dirname, "../../../../public"),
+          globOptions: {
+            ignore: [
+              "**/index.html"
+            ]
+          }
+        }
       ]
     }),
     new HtmlWebpackPlugin({


### PR DESCRIPTION
I ran into problems when creating the app with ```sbt new shadaj/create-react-scala-app.g8```.
When I started the app via ```sbt dev``` no js or css files where injected by webpack. The issues seams to be some race condition between CopyWebpackPlugin and HtmlWebpackPlugin. The CopyWebpackPlugin seems to override the created index.html from HtmlWebpackPlugin, so I added the appropriate path to the exclusion and it worked.